### PR TITLE
Cleaned up logic in SignalTester.

### DIFF
--- a/python/TestHarness/testers/SignalTester.py
+++ b/python/TestHarness/testers/SignalTester.py
@@ -8,9 +8,7 @@
 #* https://www.gnu.org/licenses/lgpl-2.1.html
 
 from RunApp import RunApp
-import os, signal,time, platform, subprocess, copy
-from TestHarness import util
-from tempfile import SpooledTemporaryFile
+import os, signal,time
 
 
 # Classes that derive from this class are expected to write
@@ -21,40 +19,62 @@ class SignalTester(RunApp):
     def validParams():
         params = RunApp.validParams()
         params.addParam('signal', "SIGUSR1", "The signal to send to the app. Defaults to SIGUSR1")
-        params.addParam('sleep_time', 1, "The amount of time the tester should wait before sending a signal.")
         return params
 
     def __init__(self, name, params):
         RunApp.__init__(self, name, params)
 
-    def send_signal(self,pid):
+        valid_signals = {
+            "SIGUSR1" : signal.SIGUSR1,
+            "SIG_DFL" : signal.SIG_DFL,
+            "SIG_IGN" : signal.SIG_IGN,
+            "SIGABRT" : signal.SIGABRT,
+            "SIGBUS"  : signal.SIGBUS,
+            "SIGCHLD" : signal.SIGCHLD,
+            "SIGCONT" : signal.SIGCONT,
+            "SIGFPE"  : signal.SIGFPE,
+            "SIGHUP"  : signal.SIGHUP,
+            "SIGILL"  : signal.SIGILL,
+            "SIGINT"  : signal.SIGINT,
+            "SIGKILL" : signal.SIGKILL,
+            "SIGPIPE" : signal.SIGPIPE,
+            "SIGSEGV" : signal.SIGSEGV,
+            "SIGTERM" : signal.SIGTERM,
+            "SIGUSR2" : signal.SIGUSR2,
+            "SIGWINCH": signal.SIGWINCH
+        }
+        try:
+            self.signal = valid_signals[self.specs["signal"]]
+        except KeyError as e:
+            print(f"Error with parameter 'signal': {self.specs['signal']} is not "
+                  f"a supported signal type. Currently supported signal types are:\n{', '.join(list(valid_signals.keys()))}")
+            raise e
+
+    def send_signal(self):
         """Function used to send a signal to the program automatically for testing purposes."""
 
-        #Create a while loop that checks if the stdout buffer has any data in it, and then sends the signal once
-        #it knows that the moose_test binary is actually doing something.
+        # Create a while loop that checks if the stdout buffer has any data in it, and then sends the signal once
+        # it knows that the moose_test binary is actually doing something.
 
-        #process.poll() will return None if the process is running in the OS.
-        #This acts as a safety precaution against an infinite loop -- this will always close.
-        while(self.process.poll() == None):
+        # process.poll() returns the process's exit code if it has completed, and None if it is still running.
+        # This acts as a safety precaution against an infinite loop -- this will always close.
+        while self.process.poll() is None:
 
-            #first, make a true duplicate of the stdout file so we don't mess with the seek on the actual file
-            out_dupe = copy.copy(self.outfile)
-            if not out_dupe.closed:
-                #go to the beginning of the file and see if its actually started running the binary
-                out_dupe.seek(0)
-                output = out_dupe.read()
+            # tell() gives the current position in the file. If it is greater than zero, the binary
+            # has started running and writing output.
+            # if the output is blank, the moose_test binary hasn't actually started doing anything yet.
+            # if so, sleep briefly and check again.
+            if not self.outfile.tell():
+                time.sleep(0.05)
 
-                #if the output is blank, the moose_test binary hasn't actually started doing anything yet.
-                #if so, sleep briefly and check again.
-                if not output:
-                    time.sleep(0.05)
-                    continue
-
-            #if the output isn't blank, then we actually sleep for the time specified in sleep_time
-            #then we finally send the SIGUSR1 and exit the loop
-            time.sleep(self.specs['sleep_time'])
-            os.kill(pid,signal.SIGUSR1)
-            break
+            # if the output isn't blank, then we finally send the signal and exit the loop
+            else:
+                try:
+                    os.kill(self.process.pid, self.signal)
+                    break
+                except ProcessLookupError as e:
+                    print("Unable to send signal to process. Has it already terminated?")
+                    raise e
 
     def runCommand(self, timer, options):
         """
@@ -68,5 +88,5 @@ class SignalTester(RunApp):
         if exit_code: # Something went wrong
             return
 
-        self.send_signal(self.process.pid)
+        self.send_signal()
         super().finishAndCleanupSubprocess(timer)

--- a/test/tests/misc/signal_handler/tests
+++ b/test/tests/misc/signal_handler/tests
@@ -6,7 +6,6 @@
     input = 'simple_transient_diffusion_scaled.i'
     requirement = 'The app should write out a checkpoint file at any time by sending a signal to it.'
     # needs short enough that the simulation has not finished
-    sleep_time = 1
     method = 'opt'
     recover = false
     max_threads = 1
@@ -43,7 +42,6 @@
   []
   [test_signal_parallel]
     type = SignalTester
-    sleep_time = 1
     input = 'simple_transient_diffusion_scaled.i'
     requirement = 'The app should write out a parallel checkpoint file at any time by sending a signal to it.'
     min_parallel = 3
@@ -86,7 +84,6 @@
   []
   [test_signal_debug]
     type = SignalTester
-    sleep_time = 4
     input = 'simple_transient_diffusion_scaled.i'
     requirement = 'The app should write out a checkpoint file at any time by sending a signal to it, in a debug build.'
     method = 'dbg'


### PR DESCRIPTION
The main part of this commit was reworking the logic in SignalTester.send_signal. Namely, the check to see if the moose binary has started running and writing to the output file was modified from an approach that copied and read the output file to a much cheaper approach that simply queried the current position in the output file.

Additionally, the 'signal' parameter previously did not do anything. This has been patched.

Finally, the 'sleep_time' parameter has been removed because it was not deemed necessary to the testing process (there should be no such thing as a signal being sent too early after the binary has started to run; the checkpoint will simply be output at the end of the next time step).

All the `signal_handler` tests passed when compiled in opt. All other framework tests passed as well, with the exception of `meshgenerators/meta_data_store.pre_split_mesh`. I do not think this failure is related to my work. When attempting the `signal_handler` tests in dbg, the following seemingly unrelated crash occurred when running `simple_diffusion_scaled.i`:

`Framework Information:
MOOSE Version:           git commit 4d5f2b9cba on 2024-01-24
LibMesh Version:         
PETSc Version:           3.20.1
SLEPc Version:           3.20.0
Current Time:            Wed Jan 24 14:55:37 2024
Executable Timestamp:    Wed Jan 24 14:52:38 2024

Parallelism:
  Num Processors:          1
  Num Threads:             1

Mesh: 
  Parallel Type:           replicated
  Mesh Dimension:          2
  Spatial Dimension:       2
  Nodes:                   1681
  Elems:                   1600
  Num Subdomains:          1

Nonlinear System:
  Num DOFs:                1681
  Num Local DOFs:          1681
  Variables:               "u" 
  Finite Element Types:    "LAGRANGE" 
  Approximation Orders:    "FIRST" 

Execution Information:
  Executioner:             Transient
  TimeStepper:             ConstantDT
  TimeIntegrator:          ImplicitEuler
  Solver Mode:             Preconditioned JFNK
  PETSc Preconditioner:    hypre boomeramg 


Time Step 0, time = 0

Time Step 1, time = 0.01, dt = 0.01

Floating point exception signaled (invalid floating point operation)!
libMesh terminating:

To track this down, compile in debug mode, then in gdb do:
  break libmesh_handleFPE
  run ...
  bt
Stack frames: 27
0: libMesh::print_trace(std::ostream&)
1: libMesh::MacroFunctions::report_error(char const*, int, char const*, char const*, std::ostream&)
2: /home/behnpa/mambaforge3/envs/moose-py311/libmesh/lib/libmesh_dbg.so.0(+0x1ffb055) [0x7f9b078d5055]
3: /lib64/libpthread.so.0(+0x12cf0) [0x7f9b01ac8cf0]
4: fedisableexcept
5: libMesh::enableFPE(bool)
6: /home/behnpa/projects/moose/framework/libmoose-dbg.so.0(+0x1af8348) [0x7f9b0b1bb348]
7: NonlinearSystemBase::computeResidualTags(std::set<unsigned int, std::less<unsigned int>, std::allocator<unsigned int> > const&)
8: FEProblemBase::computeResidualTags(std::set<unsigned int, std::less<unsigned int>, std::allocator<unsigned int> > const&)
9: FEProblemBase::computeResidualInternal(libMesh::NumericVector<double> const&, libMesh::NumericVector<double>&, std::set<unsigned int, std::less<unsigned int>, std::allocator<unsigned int> > const&)
10: FEProblemBase::computeResidual(libMesh::NumericVector<double> const&, libMesh::NumericVector<double>&, unsigned int)
11: FEProblemBase::computeResidualSys(libMesh::NonlinearImplicitSystem&, libMesh::NumericVector<double> const&, libMesh::NumericVector<double>&)
12: NonlinearSystem::solve()
13: FEProblemBase::solve(unsigned int)
14: FEProblemSolve::solve()
15: FixedPointSolve::solveStep(double&, double&, std::set<unsigned long, std::less<unsigned long>, std::allocator<unsigned long> > const&)
16: FixedPointSolve::solve()
17: TimeStepper::step()
18: Transient::takeStep(double)
19: Transient::execute()
20: MooseApp::executeExecutioner()
21: MooseTestApp::executeExecutioner()
22: MooseApp::run()
23: ../../../moose_test-dbg(+0x3e7e) [0x555e945eae7e]
24: main
25: __libc_start_main
26: ../../../moose_test-dbg(+0x3079) [0x555e945ea079]
[0] ../src/base/libmesh.C, line 134, compiled Jan 24 2024 at 10:28:50`